### PR TITLE
Allow building standalone bundles for node.js

### DIFF
--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -87,7 +87,7 @@ module.exports = {
 };
 
 function addDependency(asset, node, opts = {}) {
-  if (asset.options.target !== 'browser') {
+  if (asset.options.target !== 'browser' && !asset.options.bundleAll) {
     const isRelativeImport =
       node.value.startsWith('/') ||
       node.value.startsWith('./') ||


### PR DESCRIPTION
*Propsal*
Create new option `bundleAll` to create true standalone bundle for node and electron environments. Currently only relative files are bundled, so that's not full standalone bundle.